### PR TITLE
Decoupled playstore url

### DIFF
--- a/app/components/Social.vue
+++ b/app/components/Social.vue
@@ -38,7 +38,7 @@ export default {
   },
   methods: {
     shareUrl () {
-      SocialShare.shareUrl('http://your.playstore.link/', 'Your Playstore Link')
+      SocialShare.shareUrl(config.shareApp.playStoreUrl, config.shareApp.message)
     },
     openSocialNetwork (app, url) {
       appAvailability.available(app).then(function (avail) {

--- a/app/config.js
+++ b/app/config.js
@@ -1,5 +1,9 @@
 const config = {
   'jsondata': true,
+  'shareApp': {
+    'playStoreUrl': '',
+    'message': ''
+  },
   'sections': [
     'Live',
     'Schedule',


### PR DESCRIPTION
This PR provides:
a shareApp attribute in config.json to config an url to share

shareApp: Object
    playStoreUrl: String
    message: String
