### PR TITLE
WIP: 156 the webpack configuration breaks if i dont use create app script

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -87,7 +87,7 @@ const config = {
     shows: showsEndpoint || '/api/programs',
     podcasts: podcastsEndpoint || '/api/podcasts'
   },
-  'writeEmailTo': writeEmailTo
+  'writeEmailTo': writeEmailTo || ['info@camba.coop']
 }
 
 export default config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,8 @@ module.exports = env => {
         appId
     } = env;
 
-    const appCustomization = JSON.stringify({ ...JSON.parse(customization.split('\\').join('')), appId })
+    const appCustomization = customization &&
+      JSON.stringify({ ...JSON.parse(customization.split('\\').join('')), appId })
 
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);


### PR DESCRIPTION
This PR provides:

+   default values for **writeEmailTo** attribute in `config.js`.
+   little handling for the customization file parsing

How to manually test:

+   use this script to build an application for production:

```bash
export KEYSTORE_FILE="path to my .jks file"
export KEYSTORE_PASS="my keystore password"
export KEYSTORE_ALIAS="my keystore alias"
export KEYSTORE_ALIAS_PASS="my keystore alias password"

tns build android \
  --bundle --release \
  --key-store-path $KEYSTORE_FILE \
  --key-store-password $KEYSTORE_PASS \
  --key-store-alias $KEYSTORE_ALIAS \
  --key-store-alias-password $KEYSTORE_ALIAS_PASS \
  --compileSdk 28
```
+ try to install the generated `.apk` using:
```bash
adb install myapp.apk
```
+ try to build with just `tns build android --bundle` and try to install it too.
+ every build should finish succesfully and the app should be installable

Closes #156 