### PR TITLE
Create app tool: restore package.json and app.gradle with the original app name

### DIFF
--- a/app/App_Resources/Android/app.gradle
+++ b/app/App_Resources/Android/app.gradle
@@ -3,7 +3,7 @@
 android {
   defaultConfig {
     generatedDensities = []
-    applicationId = "org.camba.radio"
+    applicationId = "coop.radio.app"
     ndk {
       abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
     }

--- a/app/config.js
+++ b/app/config.js
@@ -25,7 +25,7 @@ const {
 } = CUSTOMIZATION
 
 const config = {
-  'appId': appId || 'org.camba.radio',
+  'appId': appId || 'coop.radio.app',
   'jsondata': true,
   'colors': {
     'appBackgroundColor': {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf platforms"
   },
   "nativescript": {
-    "id": "org.camba.radio",
+    "id": "coop.radio.app",
     "tns-ios": {
       "version": "6.0.1"
     },

--- a/tools/create-app.bash
+++ b/tools/create-app.bash
@@ -12,10 +12,11 @@ KEYSTORE_ALIAS_PASS=$7
 CONFIGURATION_FILE=$8
 GOOGLE_SERVICES_PATH=$9
 
-### Script path and directory ###
+### Script paths and directories ###
 
 FULL_PATH=$(realpath $0)
 DIRECTORY_PATH=$(dirname $FULL_PATH)
+PACKAGE_JSON_PATH=$DIRECTORY_PATH/../package.json
 
 ### Initial configuration ###
 
@@ -25,11 +26,11 @@ cp $GOOGLE_SERVICES_PATH $DIRECTORY_PATH/../app/App_Resources/Android/
 STRINGIFIED_CONFIGURATION=$(jq '. | tostring' $CONFIGURATION_FILE)
 
 APP_ID=$(jq '.client[0].client_info.android_client_info.package_name | tostring' $GOOGLE_SERVICES_PATH | tr -d "\"")
-
-LEGACY_ID="coop.radio.app"
+LEGACY_ID=$(jq '.nativescript.id | tostring' $PACKAGE_JSON_PATH | tr -d "\"")
 
 sed -i s/$LEGACY_ID/$APP_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/$LEGACY_ID/$APP_ID/g $DIRECTORY_PATH/../package.json
+sed -i s/$LEGACY_ID/$APP_ID/g $PACKAGE_JSON_PATH
+
 ### Assets ###
 
 # Place logo in the assets directory
@@ -47,4 +48,4 @@ tns resources generate icons $ASSETS_DIRECTORY/icon.png
 tns build android --bundle --release --env.customization=$STRINGIFIED_CONFIGURATION --env.appId=$APP_ID --compileSdk 28 --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASS --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASS --aab --copy-to $OUTPUT_DIRECTORY
 
 sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../package.json
+sed -i s/$APP_ID/$LEGACY_ID/g $PACKAGE_JSON_PATH

--- a/tools/create-app.bash
+++ b/tools/create-app.bash
@@ -26,9 +26,10 @@ STRINGIFIED_CONFIGURATION=$(jq '. | tostring' $CONFIGURATION_FILE)
 
 APP_ID=$(jq '.client[0].client_info.android_client_info.package_name | tostring' $GOOGLE_SERVICES_PATH | tr -d "\"")
 
-sed -i s/org.camba.radio/$APP_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/org.camba.radio/$APP_ID/g $DIRECTORY_PATH/../package.json
+LEGACY_ID="coop.radio.app"
 
+sed -i s/$LEGACY_ID/$APP_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
+sed -i s/$LEGACY_ID/$APP_ID/g $DIRECTORY_PATH/../package.json
 ### Assets ###
 
 # Place logo in the assets directory
@@ -45,5 +46,5 @@ tns resources generate icons $ASSETS_DIRECTORY/icon.png
 # Generate a .aab file
 tns build android --bundle --release --env.customization=$STRINGIFIED_CONFIGURATION --env.appId=$APP_ID --compileSdk 28 --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASS --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASS --aab --copy-to $OUTPUT_DIRECTORY
 
-sed -i s/$APP_ID/org.camba.radio/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/$APP_ID/org.camba.radio/g $DIRECTORY_PATH/../package.json
+sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
+sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../package.json


### PR DESCRIPTION
This PR provides:
- Package.json var was added in script.
- ```LEGACY_ID``` was added with package name

How to test: 
- Create an app with script.
Expected result: the package-name in app.gradle and package.json are the same than before run script.

Closes #152