### PR TITLE
166 podcasts are not shown

### DIFF
--- a/app/api/PodcastService.js
+++ b/app/api/PodcastService.js
@@ -9,10 +9,6 @@ const {
 
 export default {
   getPodcasts (qty) {
-    let options = ''
-    if (qty > 0) {
-      options += '?limit=' + qty
-    }
-    return api.get(podcasts + options)
+    return api.get(podcasts)
   }
 }

--- a/app/components/Live.vue
+++ b/app/components/Live.vue
@@ -28,6 +28,10 @@ const {
     primaryText: primaryTextColor,
     secondaryText: secondaryTextColor
   },
+  dataAdapter: {
+    currentShowAdapter,
+    showsAdapter
+  },
   stream: url
 } = config
 
@@ -79,15 +83,15 @@ export default {
     },
     setCurrentShow () {
       ShowService.getCurrentShow().then((resp) => {
-        if (this.currentShow !== resp.data.show) {
-          this.currentShow = resp.data.show
+        if (this.currentShow !== currentShowAdapter(resp).show) {
+          this.currentShow = currentShowAdapter(resp).show
           this.setImage()
         }
       })
     },
     setImage () {
       ShowService.getShows().then((shows) => {
-        this.shows = shows.data
+        this.shows = showsAdapter(shows)
         this.currentShowImage = this.shows.find((p) => { return p.title === this.currentShow }).image
       }).catch((err) => console.log(err))
     }

--- a/app/components/Podcasts.vue
+++ b/app/components/Podcasts.vue
@@ -19,7 +19,6 @@
 </template>
 <script>
 import PodcastService from '../api/PodcastService'
-import htmlToText from 'html-to-text'
 import { SET_PLAYER_SCREEN, PLAY_URL, PAUSE } from '../store/constants'
 import config from '../config.js'
 
@@ -28,6 +27,9 @@ const {
     primaryText: primaryTextColor,
     secondaryText: secondaryTextColor,
     appBackgroundColor
+  },
+  dataAdapter: {
+    podcastsAdapter
   }
 } = config
 
@@ -42,9 +44,8 @@ export default {
   },
   mounted () {
     PodcastService.getPodcasts(30).then((podcasts) => {
-      this.podcasts = podcasts.data.results.map((podcast) => {
+      this.podcasts = podcastsAdapter(podcasts).map((podcast) => {
         podcast.playing = 'paused'
-        podcast.content = htmlToText.fromString(podcast.content, { wordwrap: 200 })
         return podcast
       })
     }).catch((err) => console.log(err))

--- a/app/components/Schedule.vue
+++ b/app/components/Schedule.vue
@@ -36,6 +36,9 @@ const {
     secondaryText: {
       color: secondaryTextColor
     }
+  },
+  dataAdapter: {
+    showsAdapter
   }
 } = config
 
@@ -54,7 +57,7 @@ export default {
   mounted () {
     ShowService.getShows().then((shows) => {
       if (shows.status === 200) {
-        this.shows = shows.data
+        this.shows = showsAdapter(shows)
       }
     }).catch((err) => console.log(err))
   },

--- a/app/config.js
+++ b/app/config.js
@@ -14,7 +14,11 @@ const {
     primaryText,
     secondaryText
   },
+<<<<<<< HEAD
   phoneNumber,
+=======
+  dataAdapter,
+>>>>>>> Fixed the podcasts render
   sections,
   social: {
     facebookUrl,
@@ -90,9 +94,20 @@ const config = {
   ],
   'stream': stream,
   'endpointUrls': {
-    currentShow: currentShowEndpoint || '/api/programs/current',
+    currentShow: currentShowEndpoint || '/api/programs/current?radio_name',
     shows: showsEndpoint || '/api/programs',
-    podcasts: podcastsEndpoint || '/api/podcasts'
+    podcasts: podcastsEndpoint || '/api/podcasts?limit=30&radio_name' + applicationName
+  },
+  'dataAdapter': dataAdapter || {
+    podcastsAdapter: (response) => {
+      return response.data
+    },
+    showsAdapter: (response) => {
+      return response.data
+    },
+    currentShowAdapter: (response) => {
+      return response.data
+    }
   },
   'writeEmailTo': writeEmailTo || ['info@camba.coop']
 }

--- a/app/config.js
+++ b/app/config.js
@@ -93,7 +93,7 @@ const config = {
   'endpointUrls': {
     currentShow: currentShowEndpoint || '/api/programs/current?radio_name?radio_name=' + applicationName,
     shows: showsEndpoint || '/api/programs?radio_name=' + applicationName,
-    podcasts: podcastsEndpoint || '/api/podcasts?limit=30&radio_name' + applicationName
+    podcasts: podcastsEndpoint || '/api/podcasts?limit=30&radio_name=' + applicationName
   },
   'dataAdapter': dataAdapter || {
     podcastsAdapter: (response) => {

--- a/app/config.js
+++ b/app/config.js
@@ -14,11 +14,8 @@ const {
     primaryText,
     secondaryText
   },
-<<<<<<< HEAD
   phoneNumber,
-=======
   dataAdapter,
->>>>>>> Fixed the podcasts render
   sections,
   social: {
     facebookUrl,
@@ -94,8 +91,8 @@ const config = {
   ],
   'stream': stream,
   'endpointUrls': {
-    currentShow: currentShowEndpoint || '/api/programs/current?radio_name',
-    shows: showsEndpoint || '/api/programs',
+    currentShow: currentShowEndpoint || '/api/programs/current?radio_name?radio_name=' + applicationName,
+    shows: showsEndpoint || '/api/programs?radio_name=' + applicationName,
     podcasts: podcastsEndpoint || '/api/podcasts?limit=30&radio_name' + applicationName
   },
   'dataAdapter': dataAdapter || {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@vue/devtools": "^5.0.0-beta.3",
     "axios": "^0.18.0",
-    "html-to-text": "^5.1.1",
     "nativescript-appavailability": "^1.3.1",
     "nativescript-audio": "^5.0.0",
     "nativescript-bottom-navigation": "^1.5.1",


### PR DESCRIPTION
#### This PR provides:

  - Fix the podcasts render
  - Updated enpoint urls
  - Adapter to parse responses from the backend

#### How to test

  - run the script to generate an `.aab` file 
```
./tools/create-app.bash\
<OUTPUT_DIRECTORY>\
<ASSETS_DIRECTORY>\
<SPLASH_BACKGROUND_COLOR>\
<KEYSTORE_PATH>\
<KEYSTORE_PASS>\
<KEYSTORE_ALIAS>\
<KEYSTORE_ALIAS_PASS>\
<CONFIGURATION_FILE>\
<GOOGLE_SERVICES_PATH>
```
  - parse the `.aab` file to `.apks` file
```
java -jar bundletool.jar build-apks --bundle=<file.aab> --output=<file.apks> --ks=<keystore> --ks-pass=<keystore-pass> --ks-key-alias=<keystore-alias> --key-pass=<keystore-alias-pass>
```
  - search your device id
```
adb devices
```
  - install the `.apks` file in your device
```
java -jar bundletool.jar install-apks --apks=<file.apks> --device-id=<your-device-id>
```

#### Expected result

  - the Live screen should show the current show
  - the Schedule screen should show all the shows of the radio
  - the Podcasts screen should show all the podcasts of the radio

Closes #166 
Closes #151 