### PR TITLE
168 the create app script breaks when reading the configuration file

### DIFF
--- a/tools/create-app.bash
+++ b/tools/create-app.bash
@@ -18,34 +18,65 @@ FULL_PATH=$(realpath $0)
 DIRECTORY_PATH=$(dirname $FULL_PATH)
 PACKAGE_JSON_PATH=$DIRECTORY_PATH/../package.json
 
-### Initial configuration ###
+### Places google services configuration in the Android directory
 
 cp $GOOGLE_SERVICES_PATH $DIRECTORY_PATH/../app/App_Resources/Android/
 
-# Parse json configuration file to string
+# Parses a radio configuration json to string
 STRINGIFIED_CONFIGURATION=$(jq '. | tostring' $CONFIGURATION_FILE)
 
-APP_ID=$(jq '.client[0].client_info.android_client_info.package_name | tostring' $GOOGLE_SERVICES_PATH | tr -d "\"")
+APP_ID=$(
+  jq \
+    '.client[0].client_info.android_client_info.package_name | tostring' \
+    $GOOGLE_SERVICES_PATH | tr -d "\""
+)
 LEGACY_ID=$(jq '.nativescript.id | tostring' $PACKAGE_JSON_PATH | tr -d "\"")
 
-sed -i s/$LEGACY_ID/$APP_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/$LEGACY_ID/$APP_ID/g $PACKAGE_JSON_PATH
+# Replaces 'app.gradle' and package.json values with a given app id
+
+sed -i \
+  s/$LEGACY_ID/$APP_ID/g \
+  $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
+
+sed -i \
+  s/$LEGACY_ID/$APP_ID/g \
+  $PACKAGE_JSON_PATH
 
 ### Assets ###
 
-# Place logo in the assets directory
+# Places logo in the assets directory
 cp $ASSETS_DIRECTORY/logo.png $DIRECTORY_PATH/../app/assets/images/
 
-# Generate splash screen
-tns resources generate splashes $ASSETS_DIRECTORY/splash.png --background $SPLASH_BACKGROUND_COLOR
+# Generates a splash screen
+tns resources generate splashes \
+  $ASSETS_DIRECTORY/splash.png \
+  --background $SPLASH_BACKGROUND_COLOR
 
-# Generate app icon
+# Generates icons
 tns resources generate icons $ASSETS_DIRECTORY/icon.png
 
 ### Build ###
 
-# Generate a .aab file
-tns build android --bundle --release --env.customization="$STRINGIFIED_CONFIGURATION" --env.appId=$APP_ID --compileSdk 28 --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASS --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASS --aab --copy-to $OUTPUT_DIRECTORY
+# Generates an .aab file
+tns build android \
+  --bundle \
+  --release \
+  --env.customization="$STRINGIFIED_CONFIGURATION" \
+  --env.appId=$APP_ID \
+  --compileSdk 28 \
+  --key-store-path $KEYSTORE_PATH \
+  --key-store-password $KEYSTORE_PASS \
+  --key-store-alias $KEYSTORE_ALIAS \
+  --key-store-alias-password $KEYSTORE_ALIAS_PASS \
+  --aab \
+  --copy-to $OUTPUT_DIRECTORY
 
-sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
-sed -i s/$APP_ID/$LEGACY_ID/g $PACKAGE_JSON_PATH
+# Restores original values to 'app.gradle' and 'package.json'
+
+sed -i \
+  s/$APP_ID/$LEGACY_ID/g \
+  $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
+
+sed -i \
+  s/$APP_ID/$LEGACY_ID/g \
+  $PACKAGE_JSON_PATH

--- a/tools/create-app.bash
+++ b/tools/create-app.bash
@@ -45,7 +45,7 @@ tns resources generate icons $ASSETS_DIRECTORY/icon.png
 ### Build ###
 
 # Generate a .aab file
-tns build android --bundle --release --env.customization=$STRINGIFIED_CONFIGURATION --env.appId=$APP_ID --compileSdk 28 --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASS --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASS --aab --copy-to $OUTPUT_DIRECTORY
+tns build android --bundle --release --env.customization="$STRINGIFIED_CONFIGURATION" --env.appId=$APP_ID --compileSdk 28 --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASS --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASS --aab --copy-to $OUTPUT_DIRECTORY
 
 sed -i s/$APP_ID/$LEGACY_ID/g $DIRECTORY_PATH/../app/App_Resources/Android/app.gradle
 sed -i s/$APP_ID/$LEGACY_ID/g $PACKAGE_JSON_PATH


### PR DESCRIPTION
This PR provides:

+ fix for configuration file attributes name with white spaces
+ little refactor for readability

**How to test:**

1.   Use a configuration file with a `humanReadableName` with white spces
2.   Build an application using the script
**Expected result:** the build should not break after icons are generated

Closes #168 